### PR TITLE
Refactoring EKS cluster configuration with IAM roles, SG and VPC

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,4 @@
-# data "aws_iam_role" "eks-cluster-role" {
-#   name = "lanchonete-eks-cluster-role"
-# }
-
-# data "aws_vpc" "vpc" {
-#   cidr_block = var.vpc_cidr
-# }
+data "aws_ssm_parameter" "eks_ami" {
+  // 1.27 refers to the Kubernetes version
+  name = "/aws/service/eks/optimized-ami/1.27/amazon-linux-2/recommended/image_id"
+}

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -1,9 +1,30 @@
-resource "aws_eks_cluster" "lanchonete-eks-cluster" {
+resource "aws_iam_role" "eks_role" {
+  name = "eks_cluster_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "eks.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_policy_attachment" "eks_policy" {
+  name       = "eks_policy"
+  roles      = [aws_iam_role.eks_role.name]
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+
+resource "aws_eks_cluster" "eks_lanchonete_cluster" {
   name     = var.cluster_name
-  role_arn = var.cluster_role
+  role_arn = aws_iam_role.eks_role.arn
 
   vpc_config {
-    subnet_ids         = ["${var.subnet_a}", "${var.subnet_b}", "${var.subnet_c}"]
+    subnet_ids         = aws_subnet.eks_subnet.*.id
     security_group_ids = [aws_security_group.eks-cluster-sg.id]
   }
 
@@ -11,4 +32,4 @@ resource "aws_eks_cluster" "lanchonete-eks-cluster" {
     authentication_mode = var.access_config
   }
 }
-  
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,34 @@
-output "endpoint" {
-  value = aws_eks_cluster.lanchonete-eks-cluster.endpoint
+output "cluster_name" {
+  description = "EKS cluster name"
+  value       = aws_eks_cluster.eks_lanchonete_cluster.name
+}
+
+output "cluster_endpoint" {
+  description = "EKS cluster endpoint"
+  value       = aws_eks_cluster.eks_lanchonete_cluster.endpoint
 }
 
 output "kubeconfig-certificate-authority-data" {
-  value = aws_eks_cluster.lanchonete-eks-cluster.certificate_authority.0.data
+  description = "EKS cluster certificate authority data"
+  value       = aws_eks_cluster.eks_lanchonete_cluster.certificate_authority.0.data
+}
+
+output "region" {
+  description = "AWS region"
+  value       = var.region
+}
+
+output "vpc_id" {
+  description = "VPC ID"
+  value       = aws_vpc.eks_vpc.id
+}
+
+output "worker_role_arn" {
+  description = "Worker node IAM role ARN"
+  value       = aws_iam_role.eks_worker_role.arn
+}
+
+output "security_group_id" {
+  description = "Security group ID"
+  value       = aws_security_group.eks-cluster-sg.id
 }

--- a/provider.tf
+++ b/provider.tf
@@ -1,4 +1,3 @@
 provider "aws" {
-  # profile = "default"
   region = var.region
 }

--- a/security_group.tf
+++ b/security_group.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "eks-cluster-sg" {
   name        = "SG-${var.cluster_name}"
   description = "Security group for EKS cluster"
-  vpc_id      = var.vpc_cidr
+  vpc_id      = aws_vpc.eks_vpc.id
 
   ingress {
     description = "Allow all HTTP inbound traffic"
@@ -33,5 +33,9 @@ resource "aws_security_group" "eks-cluster-sg" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/16"]
+  }
+
+  tags = {
+    Name = "eks_cluster_sg"
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,13 +1,13 @@
 terraform {
- 
- /* cloud {
+
+  cloud {
     organization = "tc_fiap"
 
     workspaces {
       name = "infra-kitchen"
     }
   }
-*/
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/variables.tf
+++ b/variables.tf
@@ -4,53 +4,41 @@ variable "region" {
   type        = string
 }
 
-variable "cluster_name" {
-  default = "lanchonete-eks-cluster"
-  type    = string
-}
-
 // Change the account_id to your AWS account ID
-variable "account_id" {
-  default = "830714066230"
+# variable "account_id" {
+#   default = "830714066230"
+#   type    = string
+# }
+
+variable "cluster_name" {
+  default = "eks-lanchonete-cluster"
   type    = string
 }
 
-variable "cluster_role" {
-  default = "arn:aws:iam::830714066230:role/eks-cluster-role"
-}
+# variable "cluster_role" {
+#   default = "arn:aws:iam::830714066230:role/eks-cluster-role"
+# }
 
 variable "vpc_cidr" {
   description = "The CIDR block for the VPC"
   default     = "10.0.0.0/16"
 }
 
-variable "subnet_a" {
-  default = "<subnet-id>"
-}
-
-variable "subnet_b" {
-  default = "<subnet-id>"
-}
-
-variable "subnet_c" {
-  default = "<subnet-id>"
-}
-
 variable "instance_type" {
   description = "The type of instance to launch"
-  default     = "t2.micro"
+  default     = "t3.medium"
 }
 
-variable "instance_name" {
-  description = "EC2 instance name"
-  default     = "Provisioned by Terraform"
-}
+# variable "instance_name" {
+#   description = "EC2 instance name"
+#   default     = "Provisioned by Terraform"
+# }
 
 variable "access_config" {
   description = "The authentication mode for the EKS cluster"
   default     = "API_AND_CONFIG_MAP"
 }
 
-variable "policy_arn" {
-  default = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
-}
+# variable "policy_arn" {
+#   default = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+# }

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,0 +1,34 @@
+resource "aws_vpc" "eks_vpc" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags = {
+    Name = "eks-vpc"
+  }
+}
+
+resource "aws_subnet" "eks_subnet" {
+  count             = 3
+  vpc_id            = aws_vpc.eks_vpc.id
+  cidr_block        = cidrsubnet(aws_vpc.eks_vpc.cidr_block, 8, count.index)
+  availability_zone = element(["us-east-1a", "us-east-1b", "us-east-1c"], count.index)
+}
+
+resource "aws_route_table_association" "eks_route_table_assoc" {
+  count          = 3
+  subnet_id      = element(aws_subnet.eks_subnet.*.id, count.index)
+  route_table_id = aws_route_table.eks_route_table.id
+}
+
+resource "aws_internet_gateway" "eks_igw" {
+  vpc_id = aws_vpc.eks_vpc.id
+}
+
+resource "aws_route_table" "eks_route_table" {
+  vpc_id = aws_vpc.eks_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.eks_igw.id
+  }
+}

--- a/workers_node.tf
+++ b/workers_node.tf
@@ -1,0 +1,36 @@
+resource "aws_iam_role" "eks_worker_role" {
+  name = "eks_worker_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_policy_attachment" "eks_worker_policy" {
+  name       = "eks_worker_policy"
+  roles      = [aws_iam_role.eks_worker_role.name]
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_launch_configuration" "worker_launch_config" {
+  name_prefix          = "eks-worker-node"
+  image_id             = data.aws_ssm_parameter.eks_ami.value
+  instance_type        = var.instance_type
+  iam_instance_profile = aws_iam_role.eks_worker_role.name
+}
+
+resource "aws_autoscaling_group" "worker_auto_scaling_group" {
+  name                 = "eks-worker-node-asg"
+  min_size             = 1
+  desired_capacity     = 2
+  max_size             = 3
+  launch_configuration = aws_launch_configuration.worker_launch_config.id
+  vpc_zone_identifier  = aws_subnet.eks_subnet.*.id
+}


### PR DESCRIPTION
This pull request includes significant updates to the Terraform configuration for an EKS cluster setup. The changes involve the addition of new resources, updates to existing configurations, and the removal of deprecated or unused variables.

### EKS Cluster Configuration Updates:

* **IAM Roles and Policies:**
  * Added `aws_iam_role` and `aws_iam_policy_attachment` for the EKS cluster role (`eks-cluster.tf`).
  * Added `aws_iam_role` and `aws_iam_policy_attachment` for worker nodes (`workers_node.tf`).

* **VPC and Subnets:**
  * Introduced a new `aws_vpc` resource and associated subnets, route tables, and internet gateway (`vpc.tf`).

* **Outputs:**
  * Updated and added new output variables to provide more detailed information about the EKS cluster and related resources (`outputs.tf`).

* **Security Group:**
  * Updated the VPC ID reference and added tags to the security group (`security_group.tf`). [[1]](diffhunk://#diff-227592f057f0a25e59a089bb726b7ae0b2baff4a58acdaba04b4dae8d1dc2400L4-R4) [[2]](diffhunk://#diff-227592f057f0a25e59a089bb726b7ae0b2baff4a58acdaba04b4dae8d1dc2400R37-R40)

* **Provider Configuration:**
  * Cleaned up the AWS provider configuration by removing commented-out profile settings (`provider.tf`).

These changes enhance the EKS cluster setup by improving resource management, providing more detailed output information, and cleaning up the Terraform configuration.

----

TF plan

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_autoscaling_group.worker_auto_scaling_group will be created
  + resource "aws_autoscaling_group" "worker_auto_scaling_group" {
      + arn                              = (known after apply)
      + availability_zones               = (known after apply)
      + default_cooldown                 = (known after apply)
      + desired_capacity                 = 2
      + force_delete                     = false
      + force_delete_warm_pool           = false
      + health_check_grace_period        = 300
      + health_check_type                = (known after apply)
      + id                               = (known after apply)
      + ignore_failed_scaling_activities = false
      + launch_configuration             = (known after apply)
      + load_balancers                   = (known after apply)
      + max_size                         = 3
      + metrics_granularity              = "1Minute"
      + min_size                         = 1
      + name                             = "eks-worker-node-asg"
      + name_prefix                      = (known after apply)
      + predicted_capacity               = (known after apply)
      + protect_from_scale_in            = false
      + service_linked_role_arn          = (known after apply)
      + target_group_arns                = (known after apply)
      + vpc_zone_identifier              = (known after apply)
      + wait_for_capacity_timeout        = "10m"
      + warm_pool_size                   = (known after apply)

      + launch_template (known after apply)

      + mixed_instances_policy (known after apply)

      + traffic_source (known after apply)
    }

  # aws_eks_cluster.eks_lanchonete_cluster will be created
  + resource "aws_eks_cluster" "eks_lanchonete_cluster" {
      + arn                           = (known after apply)
      + bootstrap_self_managed_addons = true
      + certificate_authority         = (known after apply)
      + cluster_id                    = (known after apply)
      + created_at                    = (known after apply)
      + endpoint                      = (known after apply)
      + id                            = (known after apply)
      + identity                      = (known after apply)
      + name                          = "eks-lanchonete-cluster"
      + platform_version              = (known after apply)
      + role_arn                      = (known after apply)
      + status                        = (known after apply)
      + tags_all                      = (known after apply)
      + version                       = (known after apply)

      + access_config {
          + authentication_mode = "API_AND_CONFIG_MAP"
        }

      + kubernetes_network_config (known after apply)

      + upgrade_policy (known after apply)

      + vpc_config {
          + cluster_security_group_id = (known after apply)
          + endpoint_private_access   = false
          + endpoint_public_access    = true
          + public_access_cidrs       = (known after apply)
          + security_group_ids        = (known after apply)
          + subnet_ids                = (known after apply)
          + vpc_id                    = (known after apply)
        }
    }

  # aws_iam_policy_attachment.eks_policy will be created
  + resource "aws_iam_policy_attachment" "eks_policy" {
      + id         = (known after apply)
      + name       = "eks_policy"
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
      + roles      = [
          + "eks_cluster_role",
        ]
    }

  # aws_iam_policy_attachment.eks_worker_policy will be created
  + resource "aws_iam_policy_attachment" "eks_worker_policy" {
      + id         = (known after apply)
      + name       = "eks_worker_policy"
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
      + roles      = [
          + "eks_worker_role",
        ]
    }

  # aws_iam_role.eks_role will be created
  + resource "aws_iam_role" "eks_role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "eks.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "eks_cluster_role"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy (known after apply)
    }

  # aws_iam_role.eks_worker_role will be created
  + resource "aws_iam_role" "eks_worker_role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "ec2.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "eks_worker_role"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy (known after apply)
    }

  # aws_internet_gateway.eks_igw will be created
  + resource "aws_internet_gateway" "eks_igw" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + owner_id = (known after apply)
      + tags_all = (known after apply)
      + vpc_id   = (known after apply)
    }

  # aws_launch_configuration.worker_launch_config will be created
  + resource "aws_launch_configuration" "worker_launch_config" {
      + arn                         = (known after apply)
      + associate_public_ip_address = (known after apply)
      + ebs_optimized               = (known after apply)
      + enable_monitoring           = true
      + iam_instance_profile        = "eks_worker_role"
      + id                          = (known after apply)
      + image_id                    = (sensitive value)
      + instance_type               = "t3.medium"
      + key_name                    = (known after apply)
      + name                        = (known after apply)
      + name_prefix                 = "eks-worker-node"

      + ebs_block_device (known after apply)

      + metadata_options (known after apply)

      + root_block_device (known after apply)
    }

  # aws_route_table.eks_route_table will be created
  + resource "aws_route_table" "eks_route_table" {
      + arn              = (known after apply)
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = [
          + {
              + cidr_block                 = "0.0.0.0/0"
              + gateway_id                 = (known after apply)
                # (11 unchanged attributes hidden)
            },
        ]
      + tags_all         = (known after apply)
      + vpc_id           = (known after apply)
    }

  # aws_route_table_association.eks_route_table_assoc[0] will be created
  + resource "aws_route_table_association" "eks_route_table_assoc" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # aws_route_table_association.eks_route_table_assoc[1] will be created
  + resource "aws_route_table_association" "eks_route_table_assoc" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # aws_route_table_association.eks_route_table_assoc[2] will be created
  + resource "aws_route_table_association" "eks_route_table_assoc" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # aws_security_group.eks-cluster-sg will be created
  + resource "aws_security_group" "eks-cluster-sg" {
      + arn                    = (known after apply)
      + description            = "Security group for EKS cluster"
      + egress                 = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/16",
                ]
              + description      = "Allow all outbound traffic"
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
      + id                     = (known after apply)
      + ingress                = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = "Allow all HTTP inbound traffic"
              + from_port        = 80
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 80
            },
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = "Allow all HTTPS inbound traffic"
              + from_port        = 443
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 443
            },
          + {
              + cidr_blocks      = [
                  + "10.0.0.0/16",
                ]
              + description      = "Allow VPC inbound traffic"
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
      + name                   = "SG-eks-lanchonete-cluster"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "eks_cluster_sg"
        }
      + tags_all               = {
          + "Name" = "eks_cluster_sg"
        }
      + vpc_id                 = (known after apply)
    }

  # aws_subnet.eks_subnet[0] will be created
  + resource "aws_subnet" "eks_subnet" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-1a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.0.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags_all                                       = (known after apply)
      + vpc_id                                         = (known after apply)
    }

  # aws_subnet.eks_subnet[1] will be created
  + resource "aws_subnet" "eks_subnet" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-1b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.1.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags_all                                       = (known after apply)
      + vpc_id                                         = (known after apply)
    }

  # aws_subnet.eks_subnet[2] will be created
  + resource "aws_subnet" "eks_subnet" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-1c"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.2.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags_all                                       = (known after apply)
      + vpc_id                                         = (known after apply)
    }

  # aws_vpc.eks_vpc will be created
  + resource "aws_vpc" "eks_vpc" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.0.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_dns_hostnames                 = true
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags                                 = {
          + "Name" = "eks-vpc"
        }
      + tags_all                             = {
          + "Name" = "eks-vpc"
        }
    }

Plan: 17 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + cluster_endpoint                      = (known after apply)
  + cluster_name                          = "eks-lanchonete-cluster"
  + kubeconfig-certificate-authority-data = (known after apply)
  + region                                = "us-east-1"
  + security_group_id                     = (known after apply)
  + vpc_id                                = (known after apply)
  + worker_role_arn                       = (known after apply)

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```