### PR TITLE
Enhance README.md with detailed Terraform plan and apply flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,31 @@ This infrastructure uses an AWS Academy account (which has limited resources and
 
 - `terraform init` - command used to initializing terraform in our local directory;
 - `terraform fmt` - formats the .tf files by correcting indentation;
-- `terraform validate` - checks that verify whether a configuration is syntactically valid and internally consistent, regardless of any provided variables or existing state
-- `terraform plan` - used do creates the execution plan to preview the changes in the provider infrastructure.
+- `terraform validate` - checks that verify whether a configuration is syntactically valid and internally consistent, regardless of any provided variables or existing state;
+- `terraform plan` - used do creates the execution plan to preview the changes in the provider infrastructure;
 
 ## HCP integration
 
 This infrastructure is provisioned using [HCP Terraform](https://developer.hashicorp.com/terraform/cloud-docs), which manages Terraform runs in a consistent environment. It facilitates collaboration by allowing team members to share access and iterate on the Terraform state easily. Each collaborator must have an account on the platform to contribute effectively.
+
+### Plan and Apply flows
+
+Every push to the repository triggers a `terraform plan` to preview the changes in the infrastructure. After a merge, another `terraform plan` is executed followed by a `terraform apply` to implement the changes. You can follow these actions by clicking on the GitHub checks, which will redirect you to the HCP platform for detailed logs and status updates.
+
+#### Destroy and Deletion Flows
+
+For security reasons, deletion operations must be scheduled or triggered directly from the HCP workspace settings. This ensures that only authorized personnel can initiate such critical actions, preventing accidental or malicious deletions. Follow these steps to perform a deletion:
+
+1. Navigate to the [HCP infra-kitchen workspace](https://app.terraform.io/app/tc_fiap/workspaces).
+2. Go to the **Settings** tab.
+3. Select **Destruction and Deletion** from the menu.
+4. Schedule or trigger the deletion as required.
+
+Ensure you have the necessary permissions to perform these actions and use them carefully.
+
+### Repository ruleset
+
+<!-- TODO -->
 
 ## Continuous Integration
 ### TF Lint Checks


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to improve the documentation for Terraform commands and add new sections on plan and apply flows, as well as destroy and deletion flows. The most important changes include formatting corrections, new documentation sections, and detailed instructions for deletion operations.

Documentation improvements:

* Corrected punctuation for `terraform validate` and `terraform plan` command descriptions to improve readability.

New sections added:

* Added a new section on "Plan and Apply flows" to explain the automated process for previewing and implementing changes in the infrastructure.
* Added a new section on "Destroy and Deletion Flows" with detailed steps for performing deletion operations securely through the HCP workspace settings.