### PR TITLE
Add EBS CSI driver addon to EKS cluster configuration

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -12,3 +12,15 @@ resource "aws_eks_cluster" "eks_lanchonete_cluster" {
   }
 }
 
+resource "aws_eks_addon" "ebs_csi_driver" {
+  cluster_name = aws_eks_cluster.eks_lanchonete_cluster.name
+  addon_name   = "aws-ebs-csi-driver"
+
+  depends_on = [aws_eks_node_group.eks_lanchonete_node_group]
+
+
+  tags = {
+    name = "ebs-lanchonete-csi-driver"
+  }
+
+}


### PR DESCRIPTION
This pull request adds a new resource to the `eks-cluster.tf` file to support an EBS CSI driver addon for the EKS cluster. The most important changes include the addition of the `aws_eks_addon` resource and its associated configuration.

### Additions:

* [`eks-cluster.tf`](diffhunk://#diff-f5beb059014dcc89c53714a1c7d4cbd952cf41e6d06eed550d1f8877ce65d1caR15-R26): Added a new `aws_eks_addon` resource named `ebs_csi_driver` to manage the EBS CSI driver addon for the EKS cluster. This includes specifying the cluster name, addon name, dependencies, and tags.